### PR TITLE
Home setting and storage contract initial integration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -388,7 +388,6 @@ class App extends React.Component {
       wrapper,
       homeSettings,
     } = this.state
-    console.log(homeSettings)
     const { mode, dao } = locator
     const { address: intentAddress = null, label: intentLabel = '' } =
       identityIntent || {}
@@ -417,8 +416,6 @@ class App extends React.Component {
 
     return (
       <IdentityProvider onResolve={this.handleIdentityResolve}>
-        {this.state.homeSettings.address}
-        {this.state.homeSettings.name}
         <ModalProvider>
           <LocalIdentityModalProvider
             onShowLocalIdentityModal={this.handleOpenLocalIdentityModal}
@@ -465,6 +462,7 @@ class App extends React.Component {
                       walletWeb3={walletWeb3}
                       web3={web3}
                       wrapper={wrapper}
+                      homeSettings={homeSettings}
                     />
                   </div>
                 </PermissionsProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -47,6 +47,7 @@ const INITIAL_DAO_STATE = {
   permissions: {},
   permissionsLoading: true,
   repos: [],
+  homeSettings: { address: '', name: '' },
 }
 
 class App extends React.Component {
@@ -289,6 +290,15 @@ class App extends React.Component {
           },
         })
       },
+      onHomeApp: homeSettings => {
+        log('home updated', homeSettings)
+        this.setState(prevState => {
+          const newHomeSettings = { ...prevState.homeSettings, ...homeSettings }
+          return {
+            homeSettings: newHomeSettings,
+          }
+        })
+      },
     })
       .then(wrapper => {
         log('wrapper', wrapper)
@@ -376,8 +386,9 @@ class App extends React.Component {
       walletWeb3,
       web3,
       wrapper,
+      homeSettings,
     } = this.state
-
+    console.log(homeSettings)
     const { mode, dao } = locator
     const { address: intentAddress = null, label: intentLabel = '' } =
       identityIntent || {}
@@ -406,6 +417,8 @@ class App extends React.Component {
 
     return (
       <IdentityProvider onResolve={this.handleIdentityResolve}>
+        {this.state.homeSettings.address}
+        {this.state.homeSettings.name}
         <ModalProvider>
           <LocalIdentityModalProvider
             onShowLocalIdentityModal={this.handleOpenLocalIdentityModal}

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -200,8 +200,6 @@ class Wrapper extends React.PureComponent {
           instances: [instance],
           hasWebApp: app.hasWebApp,
           repoName: app.appName,
-          isHomeApp: app.isHomeApp,
-          menuName: app.menuName,
         },
       ])
     }, [])
@@ -337,6 +335,7 @@ class Wrapper extends React.PureComponent {
           dao={locator.dao}
           onMessage={this.handleAppMessage}
           onOpenApp={this.openApp}
+          homeSettings={homeSettings}
         />
       )
     }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -199,7 +199,7 @@ class Wrapper extends React.PureComponent {
           hasWebApp: app.hasWebApp,
           repoName: app.appName,
           isHomeApp: app.isHomeApp,
-          menuName: app.menuName,
+          menuAlias: app.menuAlias,
         },
       ])
     }, [])

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -20,6 +20,7 @@ import {
   DaoStatusType,
   EthereumAddressType,
   RepoType,
+  HomeSettingsType,
 } from './prop-types'
 import { getAppPath } from './routing'
 import { APPS_STATUS_LOADING } from './symbols'
@@ -51,6 +52,7 @@ class Wrapper extends React.PureComponent {
     walletWeb3: PropTypes.object,
     web3: PropTypes.object,
     wrapper: AragonType,
+    homeSettings: HomeSettingsType,
   }
 
   static defaultProps = {
@@ -234,6 +236,7 @@ class Wrapper extends React.PureComponent {
       walletWeb3,
       web3,
       wrapper,
+      homeSettings,
     } = this.props
 
     const {
@@ -275,6 +278,7 @@ class Wrapper extends React.PureComponent {
           onRequestAppsReload={onRequestAppsReload}
           onRequestEnable={onRequestEnable}
           opened={menuPanelOpened}
+          homeSettings={homeSettings}
         >
           <AppScreen>
             {this.renderApp(locator.instanceId, locator.params)}
@@ -318,6 +322,7 @@ class Wrapper extends React.PureComponent {
       walletNetwork,
       walletWeb3,
       wrapper,
+      homeSettings,
     } = this.props
 
     const appsLoading = appsStatus === APPS_STATUS_LOADING
@@ -376,6 +381,7 @@ class Wrapper extends React.PureComponent {
           walletNetwork={walletNetwork}
           walletWeb3={walletWeb3}
           wrapper={wrapper}
+          homeSettings={homeSettings}
         />
       )
     }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -198,6 +198,7 @@ class Wrapper extends React.PureComponent {
           instances: [instance],
           hasWebApp: app.hasWebApp,
           repoName: app.appName,
+          isHomeApp: app.isHomeApp,
         },
       ])
     }, [])

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -199,6 +199,7 @@ class Wrapper extends React.PureComponent {
           hasWebApp: app.hasWebApp,
           repoName: app.appName,
           isHomeApp: app.isHomeApp,
+          menuName: app.menuName,
         },
       ])
     }, [])

--- a/src/apps/Permissions/AppRoles.js
+++ b/src/apps/Permissions/AppRoles.js
@@ -82,8 +82,10 @@ class AppRoles extends React.PureComponent {
 class RoleRow extends React.Component {
   static propTypes = {
     onManage: PropTypes.func.isRequired,
-    role: PropTypes.shape({ bytes: PropTypes.string }).isRequired,
+    role: PropTypes.shape({ bytes: PropTypes.string, name: PropTypes.string })
+      .isRequired,
     manager: PropTypes.shape({
+      app: PropTypes.object,
       type: PropTypes.string,
       address: EthereumAddressType,
     }).isRequired,

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Button, DropDown, Field, TextInput } from '@aragon/ui'
 
-import { AppType } from '../../prop-types'
+import { AppType, AragonType, HomeSettingsType } from '../../prop-types'
 import AragonStorage from '../../storage/storage-wrapper'
 
 import Option from './Option'
@@ -13,6 +13,8 @@ const defaultOption = 'Use the default'
 class HomeSettings extends React.Component {
   static propTypes = {
     apps: PropTypes.arrayOf(AppType).isRequired,
+    wrapper: AragonType,
+    homeSettings: HomeSettingsType,
   }
   state = {
     homeAppAlias: 'Home',
@@ -21,8 +23,8 @@ class HomeSettings extends React.Component {
     dirty: false,
   }
 
-  async getHomeSettings(props) {
-    const { apps, homeSettings } = props
+  async setHomeSettings() {
+    const { apps, homeSettings } = this.props
     const { dirty } = this.state
     const storageApp = apps.find(({ name }) => name === 'Storage')
 
@@ -39,11 +41,11 @@ class HomeSettings extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.getHomeSettings(nextProps)
+  componentWillReceiveProps() {
+    this.setHomeSettings()
   }
   componentWillMount() {
-    this.getHomeSettings(this.props)
+    this.setHomeSettings()
   }
 
   handleHomeAppChange = (index, apps) => {

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -8,7 +8,7 @@ import AragonStorage from '../../storage/storage-wrapper'
 
 import Option from './Option'
 
-const defaultName = 'Use the default'
+const defaultOption = 'Use the default'
 
 class HomeSettings extends React.Component {
   static propTypes = {
@@ -18,7 +18,7 @@ class HomeSettings extends React.Component {
   }
   state = {
     homeAppName: 'Home',
-    selectedHomeAppName: defaultName,
+    selectedHomeAppName: defaultOption,
     storageApp: null,
   }
 
@@ -53,7 +53,7 @@ class HomeSettings extends React.Component {
     this.setState({
       homeAppName: homeAppName,
       selectedHomeAppName:
-        (selectedHomeApp && selectedHomeApp.name) || defaultName,
+        (selectedHomeApp && selectedHomeApp.name) || defaultOption,
       storageApp: apps.find(({ name }) => name === 'Storage'),
     })
   }
@@ -85,7 +85,7 @@ class HomeSettings extends React.Component {
       )
 
       try {
-        if (selectedHomeAppName !== defaultName) {
+        if (selectedHomeAppName !== defaultOption) {
           await AragonStorage.set(
             walletWeb3,
             storageApp.proxyAddress,
@@ -118,7 +118,7 @@ class HomeSettings extends React.Component {
         app.hasWebApp && filtered.push(app.name)
         return filtered
       },
-      [defaultName]
+      [defaultOption]
     )
     if (!storageApp) return <div />
 
@@ -136,7 +136,7 @@ class HomeSettings extends React.Component {
               wide
             />
           </Field>
-          {selectedHomeAppName !== defaultName ? (
+          {selectedHomeAppName !== defaultOption ? (
             <Field label="Enter tab name">
               <TextInput
                 onChange={this.handleHomeNameChange}

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -23,39 +23,20 @@ class HomeSettings extends React.Component {
   }
 
   async getHomeSettings(props) {
-    const { apps, walletWeb3, account } = props
+    const { apps, homeSettings } = props
     const storageApp = apps.find(({ name }) => name === 'Storage')
-    let homeAppName, homeAppAddr
 
-    // TODO: Move this code to a subscriber
     if (storageApp && storageApp.proxyAddress) {
-      homeAppAddr = await AragonStorage.get(
-        walletWeb3,
-        storageApp.proxyAddress,
-        account,
-        'HOME_APP'
+      const selectedHomeApp = apps.find(
+        ({ proxyAddress }) => proxyAddress === homeSettings.address
       )
-
-      homeAppName = await AragonStorage.get(
-        walletWeb3,
-        storageApp.proxyAddress,
-        account,
-        'HOME_APP_NAME'
-      )
-      if (!homeAppName) {
-        homeAppName = 'Home'
-      }
+      this.setState({
+        homeAppName: homeSettings.name,
+        selectedHomeAppName:
+          (selectedHomeApp && selectedHomeApp.name) || defaultName,
+        storageApp: apps.find(({ name }) => name === 'Storage'),
+      })
     }
-    const selectedHomeApp = apps.find(
-      ({ proxyAddress }) => proxyAddress === homeAppAddr
-    )
-
-    this.setState({
-      homeAppName: homeAppName,
-      selectedHomeAppName:
-        (selectedHomeApp && selectedHomeApp.name) || defaultName,
-      storageApp: apps.find(({ name }) => name === 'Storage'),
-    })
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -17,15 +17,15 @@ class HomeSettings extends React.Component {
     walletWeb3: PropTypes.object.isRequired,
   }
   state = {
-    homeAppName: 'Home',
-    selectedHomeAppName: defaultOption,
+    homeAppAlias: 'Home',
+    selectedhomeAppAlias: defaultOption,
     storageApp: null,
   }
 
   async getHomeSettings(props) {
     const { apps, walletWeb3, account } = props
     const storageApp = apps.find(({ name }) => name === 'Storage')
-    let homeAppName, homeAppAddr
+    let homeAppAlias, homeAppAddr
 
     // TODO: Move this code to a subscriber
     if (storageApp && storageApp.proxyAddress) {
@@ -36,14 +36,14 @@ class HomeSettings extends React.Component {
         'HOME_APP'
       )
 
-      homeAppName = await AragonStorage.get(
+      homeAppAlias = await AragonStorage.get(
         walletWeb3,
         storageApp.proxyAddress,
         account,
         'HOME_APP_NAME'
       )
-      if (!homeAppName) {
-        homeAppName = 'Home'
+      if (!homeAppAlias) {
+        homeAppAlias = 'Home'
       }
     }
     const selectedHomeApp = apps.find(
@@ -51,8 +51,8 @@ class HomeSettings extends React.Component {
     )
 
     this.setState({
-      homeAppName: homeAppName,
-      selectedHomeAppName:
+      homeAppAlias: homeAppAlias,
+      selectedhomeAppAlias:
         (selectedHomeApp && selectedHomeApp.name) || defaultOption,
       storageApp: apps.find(({ name }) => name === 'Storage'),
     })
@@ -66,32 +66,32 @@ class HomeSettings extends React.Component {
   }
 
   handleHomeAppChange = (index, apps) => {
-    this.setState({ selectedHomeAppName: apps[index] })
+    this.setState({ selectedhomeAppAlias: apps[index] })
   }
 
   handleHomeNameChange = event => {
     this.setState({
-      homeAppName: event.target.value && event.target.value.trim(),
+      homeAppAlias: event.target.value && event.target.value.trim(),
     })
   }
 
   handleHomeSettingsSave = async () => {
     const { walletWeb3, apps, account } = this.props
-    const { storageApp, selectedHomeAppName, homeAppName } = this.state
+    const { storageApp, selectedhomeAppAlias, homeAppAlias } = this.state
 
     if (storageApp && storageApp.proxyAddress) {
       const selectedAppAddr = apps.find(
-        ({ name }) => name === selectedHomeAppName
+        ({ name }) => name === selectedhomeAppAlias
       )
 
       try {
-        if (selectedHomeAppName !== defaultOption) {
+        if (selectedhomeAppAlias !== defaultOption) {
           await AragonStorage.set(
             walletWeb3,
             storageApp.proxyAddress,
             account,
             'HOME_APP_NAME',
-            homeAppName
+            homeAppAlias
           )
         }
 
@@ -111,7 +111,7 @@ class HomeSettings extends React.Component {
 
   render() {
     const { apps } = this.props
-    const { homeAppName, selectedHomeAppName, storageApp } = this.state
+    const { homeAppAlias, selectedhomeAppAlias, storageApp } = this.state
 
     const reducedAppNames = apps.reduce(
       (filtered, app) => {
@@ -130,17 +130,17 @@ class HomeSettings extends React.Component {
         <WideFlex>
           <Field label="Select app">
             <DropDown
-              active={reducedAppNames.indexOf(selectedHomeAppName)}
+              active={reducedAppNames.indexOf(selectedhomeAppAlias)}
               items={reducedAppNames}
               onChange={this.handleHomeAppChange}
               wide
             />
           </Field>
-          {selectedHomeAppName !== defaultOption ? (
+          {selectedhomeAppAlias !== defaultOption ? (
             <Field label="Enter tab name">
               <TextInput
                 onChange={this.handleHomeNameChange}
-                value={homeAppName}
+                value={homeAppAlias}
                 wide
               />
             </Field>

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -31,7 +31,7 @@ class HomeSettings extends React.Component {
         ({ proxyAddress }) => proxyAddress === homeSettings.address
       )
       this.setState({
-        homeAppName: homeSettings.name,
+        homeAppName: homeSettings.name || 'Home',
         selectedHomeAppName:
           (selectedHomeApp && selectedHomeApp.name) || defaultName,
         storageApp: apps.find(({ name }) => name === 'Storage'),

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -102,7 +102,7 @@ class HomeSettings extends React.Component {
           'HOME_APP',
           (selectedAppAddr && selectedAppAddr.proxyAddress) || ''
         )
-        window.location.reload(true)
+        // window.location.reload(true)
       } catch (err) {
         console.log(err)
       }

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Button, DropDown, Field, TextInput } from '@aragon/ui'
 
-import { AppType, EthereumAddressType } from '../../prop-types'
+import { AppType } from '../../prop-types'
 import AragonStorage from '../../storage/storage-wrapper'
-import { soliditySha3 } from '../../web3-utils'
 
 import Option from './Option'
 
@@ -13,9 +12,7 @@ const defaultName = 'Use the default'
 
 class HomeSettings extends React.Component {
   static propTypes = {
-    account: EthereumAddressType,
     apps: PropTypes.arrayOf(AppType).isRequired,
-    walletWeb3: PropTypes.object.isRequired,
   }
   state = {
     homeAppName: 'Home',

--- a/src/apps/Settings/HomeSettings.js
+++ b/src/apps/Settings/HomeSettings.js
@@ -1,0 +1,169 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Button, DropDown, Field, TextInput } from '@aragon/ui'
+
+import { AppType, EthereumAddressType } from '../../prop-types'
+import AragonStorage from '../../storage/storage-wrapper'
+
+import Option from './Option'
+
+const defaultName = 'Use the default'
+
+class HomeSettings extends React.Component {
+  static propTypes = {
+    account: EthereumAddressType,
+    apps: PropTypes.arrayOf(AppType).isRequired,
+    walletWeb3: PropTypes.object.isRequired,
+  }
+  state = {
+    homeAppName: 'Home',
+    selectedHomeAppName: defaultName,
+    storageApp: null,
+  }
+
+  async getHomeSettings(props) {
+    const { apps, walletWeb3, account } = props
+    const storageApp = apps.find(({ name }) => name === 'Storage')
+    let homeAppName, homeAppAddr
+
+    // TODO: Move this code to a subscriber
+    if (storageApp && storageApp.proxyAddress) {
+      homeAppAddr = await AragonStorage.get(
+        walletWeb3,
+        storageApp.proxyAddress,
+        account,
+        'HOME_APP'
+      )
+
+      homeAppName = await AragonStorage.get(
+        walletWeb3,
+        storageApp.proxyAddress,
+        account,
+        'HOME_APP_NAME'
+      )
+      if (!homeAppName) {
+        homeAppName = 'Home'
+      }
+    }
+    const selectedHomeApp = apps.find(
+      ({ proxyAddress }) => proxyAddress === homeAppAddr
+    )
+
+    this.setState({
+      homeAppName: homeAppName,
+      selectedHomeAppName:
+        (selectedHomeApp && selectedHomeApp.name) || defaultName,
+      storageApp: apps.find(({ name }) => name === 'Storage'),
+    })
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.getHomeSettings(nextProps)
+  }
+  componentWillMount() {
+    this.getHomeSettings(this.props)
+  }
+
+  handleHomeAppChange = (index, apps) => {
+    this.setState({ selectedHomeAppName: apps[index] })
+  }
+
+  handleHomeNameChange = event => {
+    this.setState({
+      homeAppName: event.target.value && event.target.value.trim(),
+    })
+  }
+
+  handleHomeSettingsSave = async () => {
+    const { walletWeb3, apps, account } = this.props
+    const { storageApp, selectedHomeAppName, homeAppName } = this.state
+
+    if (storageApp && storageApp.proxyAddress) {
+      const selectedAppAddr = apps.find(
+        ({ name }) => name === selectedHomeAppName
+      )
+
+      try {
+        if (selectedHomeAppName !== defaultName) {
+          await AragonStorage.set(
+            walletWeb3,
+            storageApp.proxyAddress,
+            account,
+            'HOME_APP_NAME',
+            homeAppName
+          )
+        }
+
+        await AragonStorage.set(
+          walletWeb3,
+          storageApp.proxyAddress,
+          account,
+          'HOME_APP',
+          (selectedAppAddr && selectedAppAddr.proxyAddress) || ''
+        )
+        window.location.reload(true)
+      } catch (err) {
+        console.log(err)
+      }
+    }
+  }
+
+  render() {
+    const { apps } = this.props
+    const { homeAppName, selectedHomeAppName, storageApp } = this.state
+
+    const reducedAppNames = apps.reduce(
+      (filtered, app) => {
+        app.hasWebApp && filtered.push(app.name)
+        return filtered
+      },
+      [defaultName]
+    )
+    if (!storageApp) return <div />
+
+    return (
+      <Option
+        name="Home Page"
+        text={`The default home page is a list of shortcuts to other apps. You can set another home page, which can be any of your existing apps. You might want to install the Home app first and select that!`}
+      >
+        <WideFlex>
+          <Field label="Select app">
+            <DropDown
+              active={reducedAppNames.indexOf(selectedHomeAppName)}
+              items={reducedAppNames}
+              onChange={this.handleHomeAppChange}
+              wide
+            />
+          </Field>
+          {selectedHomeAppName !== defaultName ? (
+            <Field label="Enter tab name">
+              <TextInput
+                onChange={this.handleHomeNameChange}
+                value={homeAppName}
+                wide
+              />
+            </Field>
+          ) : (
+            <Field />
+          )}
+        </WideFlex>
+        <Button mode="strong" onClick={this.handleHomeSettingsSave}>
+          Submit Changes
+        </Button>
+      </Option>
+    )
+  }
+}
+
+const WideFlex = styled.div`
+  display: flex;
+  > * {
+    flex: 1;
+  }
+  > :last-child {
+    margin-left: 20px;
+  }
+`
+
+export default HomeSettings

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -88,6 +88,12 @@ class Settings extends React.Component {
     window.localStorage.clear()
     window.location.reload()
   }
+  handleHomeAppChange = (index, apps) => {
+    console.log('changed app:', index, apps)
+  }
+  handleHomeNameChange = event => {
+    console.log('changed app name:', event.target.value)
+  }
 
   handleMenuPanelOpen = () => {
     this.props.onMessage({
@@ -110,9 +116,17 @@ class Settings extends React.Component {
       currencies,
       ethNode,
       ipfsGateway,
+      homeAppName = 'Home',
       selectedCurrency,
+      selectedHomeApp = 'Home',
       selectedNodeError,
     } = this.state
+
+    const reducedAppNames = apps.reduce(
+      (filtered, app) => !app.hasWebApp && filtered.push(app.name) && filtered,
+      ['Home']
+    )
+
     return (
       <AppLayout
         title="Settings"
@@ -146,6 +160,29 @@ class Settings extends React.Component {
               </Field>
             </Option>
           )}
+          <Option
+            name="Home Page"
+            text={`The default home page is a list of shortcuts to other apps. You can set another home page, which can be any of your existing apps. You might want to install the Home app first and select that!`}
+          >
+            <WideFlex>
+              <Field label="Select app">
+                <DropDown
+                  // active={apps.indexOf(selectedHomeApp)}
+                  active={0}
+                  items={reducedAppNames}
+                  onChange={this.handleHomeAppChange}
+                  wide
+                />
+              </Field>
+              <Field label="Enter tab name">
+                <TextInput
+                  onChange={this.handleHomeNameChange}
+                  value={homeAppName}
+                  wide
+                />
+              </Field>
+            </WideFlex>
+          </Option>
           <Option
             name="Node settings (advanced)"
             text={`
@@ -216,6 +253,16 @@ class Settings extends React.Component {
 
 const Content = styled.div`
   max-width: 600px;
+`
+
+const WideFlex = styled.div`
+  display: flex;
+  > * {
+    flex: 1;
+  }
+  > :last-child {
+    margin-left: 20px;
+  }
 `
 
 export default Settings

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -22,6 +22,7 @@ import { checkValidEthNode } from '../../web3-utils'
 import DaoSettings from './DaoSettings'
 import Option from './Option'
 import Note from './Note'
+import HomeSettings from './HomeSettings'
 
 // Only USD for now
 const AVAILABLE_CURRENCIES = ['USD']
@@ -137,19 +138,9 @@ class Settings extends React.Component {
       currencies,
       ethNode,
       ipfsGateway,
-      homeAppName,
       selectedCurrency,
-      selectedHomeApp,
       selectedNodeError,
     } = this.state
-
-    const reducedAppNames = apps.reduce(
-      (filtered, app) => {
-        app.hasWebApp && filtered.push(app.name)
-        return filtered
-      },
-      ['Use the default']
-    )
 
     return (
       <AppLayout
@@ -184,31 +175,7 @@ class Settings extends React.Component {
               </Field>
             </Option>
           )}
-          <Option
-            name="Home Page"
-            text={`The default home page is a list of shortcuts to other apps. You can set another home page, which can be any of your existing apps. You might want to install the Home app first and select that!`}
-          >
-            <WideFlex>
-              <Field label="Select app">
-                <DropDown
-                  active={reducedAppNames.indexOf(selectedHomeApp)}
-                  items={reducedAppNames}
-                  onChange={this.handleHomeAppChange}
-                  wide
-                />
-              </Field>
-              <Field label="Enter tab name">
-                <TextInput
-                  onChange={this.handleHomeNameChange}
-                  value={homeAppName}
-                  wide
-                />
-              </Field>
-            </WideFlex>
-            <Button mode="strong" onClick={this.handleHomeSettingsSave}>
-              Submit Changes
-            </Button>
-          </Option>
+          <HomeSettings {...this.props} />
           <Option
             name="Node settings (advanced)"
             text={`
@@ -279,16 +246,6 @@ class Settings extends React.Component {
 
 const Content = styled.div`
   max-width: 600px;
-`
-
-const WideFlex = styled.div`
-  display: flex;
-  > * {
-    flex: 1;
-  }
-  > :last-child {
-    margin-left: 20px;
-  }
 `
 
 export default Settings

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -148,7 +148,7 @@ class Settings extends React.Component {
         app.hasWebApp && filtered.push(app.name)
         return filtered
       },
-      ['Home']
+      ['Use the default']
     )
 
     return (

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -50,7 +50,7 @@ class Settings extends React.Component {
   state = {
     currencies: AVAILABLE_CURRENCIES,
     ethNode: defaultEthNode,
-    homeAppName: 'Home',
+    homeAppAlias: 'Home',
     ipfsGateway: ipfsDefaultConf.gateway,
     selectedCurrency: filterCurrency(getSelectedCurrency()),
     selectedHomeApp: 'Home',
@@ -90,31 +90,6 @@ class Settings extends React.Component {
     await this.props.wrapper.cache.clear()
     window.localStorage.clear()
     window.location.reload()
-  }
-  handleHomeAppChange = (index, apps) => {
-    // setSelectedHomeApp(apps[index])
-    this.setState({ selectedHomeApp: apps[index] })
-  }
-  handleHomeNameChange = event => {
-    this.setState({
-      homeAppName: event.target.value && event.target.value.trim(),
-    })
-  }
-  handleHomeSettingsSave = async () => {
-    const { homeAppName, selectedHomeApp } = this.state
-    console.log(
-      `App should change to ${selectedHomeApp} with the alias "${homeAppName}"`
-    )
-
-    // try {
-    // await changeHomeApp(selectedHomeApp, homeAppName)
-    // } catch (err) {
-    // this.setState({ selectedHomeError: err })
-    // return
-    // }
-
-    // For now, we have to reload the page to propagate the changes
-    // window.location.reload()
   }
 
   handleMenuPanelOpen = () => {

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -49,8 +49,10 @@ class Settings extends React.Component {
   state = {
     currencies: AVAILABLE_CURRENCIES,
     ethNode: defaultEthNode,
+    homeAppName: 'Home',
     ipfsGateway: ipfsDefaultConf.gateway,
     selectedCurrency: filterCurrency(getSelectedCurrency()),
+    selectedHomeApp: 0,
     selectedNodeError: null,
   }
   handleSelectedCurrencyChange = (index, currencies) => {
@@ -89,10 +91,13 @@ class Settings extends React.Component {
     window.location.reload()
   }
   handleHomeAppChange = (index, apps) => {
-    console.log('changed app:', index, apps)
+    // setSelectedHomeApp(apps[index])
+    this.setState({ selectedHomeApp: apps[index] })
   }
   handleHomeNameChange = event => {
-    console.log('changed app name:', event.target.value)
+    this.setState({
+      homeAppName: event.target.value && event.target.value.trim(),
+    })
   }
 
   handleMenuPanelOpen = () => {
@@ -116,14 +121,17 @@ class Settings extends React.Component {
       currencies,
       ethNode,
       ipfsGateway,
-      homeAppName = 'Home',
+      homeAppName,
       selectedCurrency,
-      selectedHomeApp = 'Home',
+      selectedHomeApp,
       selectedNodeError,
     } = this.state
 
     const reducedAppNames = apps.reduce(
-      (filtered, app) => !app.hasWebApp && filtered.push(app.name) && filtered,
+      (filtered, app) => {
+        app.hasWebApp && filtered.push(app.name)
+        return filtered
+      },
       ['Home']
     )
 
@@ -167,8 +175,7 @@ class Settings extends React.Component {
             <WideFlex>
               <Field label="Select app">
                 <DropDown
-                  // active={apps.indexOf(selectedHomeApp)}
-                  active={0}
+                  active={selectedHomeApp}
                   items={reducedAppNames}
                   onChange={this.handleHomeAppChange}
                   wide

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -175,7 +175,7 @@ class Settings extends React.Component {
               </Field>
             </Option>
           )}
-          <HomeSettings {...this.props} />
+          <HomeSettings walletWeb3={walletWeb3} apps={apps} account={account} />
           <Option
             name="Node settings (advanced)"
             text={`

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -52,7 +52,7 @@ class Settings extends React.Component {
     homeAppName: 'Home',
     ipfsGateway: ipfsDefaultConf.gateway,
     selectedCurrency: filterCurrency(getSelectedCurrency()),
-    selectedHomeApp: 0,
+    selectedHomeApp: 'Home',
     selectedNodeError: null,
   }
   handleSelectedCurrencyChange = (index, currencies) => {
@@ -98,6 +98,22 @@ class Settings extends React.Component {
     this.setState({
       homeAppName: event.target.value && event.target.value.trim(),
     })
+  }
+  handleHomeSettingsSave = async () => {
+    const { homeAppName, selectedHomeApp } = this.state
+    console.log(
+      `App should change to ${selectedHomeApp} with the alias "${homeAppName}"`
+    )
+
+    // try {
+    // await changeHomeApp(selectedHomeApp, homeAppName)
+    // } catch (err) {
+    // this.setState({ selectedHomeError: err })
+    // return
+    // }
+
+    // For now, we have to reload the page to propagate the changes
+    // window.location.reload()
   }
 
   handleMenuPanelOpen = () => {
@@ -175,7 +191,7 @@ class Settings extends React.Component {
             <WideFlex>
               <Field label="Select app">
                 <DropDown
-                  active={selectedHomeApp}
+                  active={reducedAppNames.indexOf(selectedHomeApp)}
                   items={reducedAppNames}
                   onChange={this.handleHomeAppChange}
                   wide
@@ -189,6 +205,9 @@ class Settings extends React.Component {
                 />
               </Field>
             </WideFlex>
+            <Button mode="strong" onClick={this.handleHomeSettingsSave}>
+              Submit Changes
+            </Button>
           </Option>
           <Option
             name="Node settings (advanced)"

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -39,7 +39,7 @@ const prepareAppsForFrontend = (
   daoAddress,
   gateway,
   homeAppAddr,
-  homeAppName
+  homeAppAlias
 ) => {
   const hasWebApp = app => Boolean(app['start_url'])
 
@@ -73,7 +73,7 @@ const prepareAppsForFrontend = (
 
       const isHomeApp = app.proxyAddress === homeAppAddr
       if (isHomeApp) {
-        app.menuName = homeAppName
+        app.menuAlias = homeAppAlias
       }
 
       return {
@@ -242,7 +242,7 @@ const subscribe = (
 
     apps: apps.subscribe(async apps => {
       const storageApp = apps.find(({ name }) => name === 'Storage')
-      let homeAppName = ''
+      let homeAppAlias = ''
       let homeAppAddr = ''
       if (storageApp && storageApp.proxyAddress) {
         const account = await getMainAccount(wrapper.web3)
@@ -254,7 +254,7 @@ const subscribe = (
           'HOME_APP'
         )
 
-        homeAppName = await AragonStorage.get(
+        homeAppAlias = await AragonStorage.get(
           wrapper.web3,
           storageApp.proxyAddress,
           account,
@@ -268,7 +268,7 @@ const subscribe = (
           wrapper.kernelProxy.address,
           ipfsConf.gateway,
           homeAppAddr,
-          homeAppName
+          homeAppAlias
         )
       )
     }),

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -56,6 +56,25 @@ class Home extends React.Component {
     onOpenApp: PropTypes.func.isRequired,
   }
 
+  componentDidUpdate() {
+    this.redirectHome()
+  }
+
+  componentDidMount() {
+    this.redirectHome()
+  }
+
+  redirectHome() {
+    const { apps, onOpenApp } = this.props
+    apps.map(app => {
+      if (app.isHomeApp) {
+        if (app && onOpenApp) {
+          onOpenApp(app.proxyAddress)
+        }
+      }
+    })
+  }
+
   state = {
     showApps: false,
   }

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -5,7 +5,7 @@ import { Spring, animated } from 'react-spring'
 import { Text, theme } from '@aragon/ui'
 import HomeCard from './HomeCard'
 import { lerp } from '../../math-utils'
-import { AppType } from '../../prop-types'
+import { AppType, HomeSettingsType } from '../../prop-types'
 import springs from '../../springs'
 import AppLayout from '../../components/AppLayout/AppLayout'
 
@@ -54,6 +54,7 @@ class Home extends React.Component {
     dao: PropTypes.string.isRequired,
     onMessage: PropTypes.func.isRequired,
     onOpenApp: PropTypes.func.isRequired,
+    homeSettings: HomeSettingsType,
   }
 
   componentDidUpdate() {
@@ -65,14 +66,14 @@ class Home extends React.Component {
   }
 
   redirectHome() {
-    const { apps, onOpenApp } = this.props
-    apps.map(app => {
-      if (app.isHomeApp) {
-        if (app && onOpenApp) {
-          onOpenApp(app.proxyAddress)
-        }
+    const { onOpenApp, homeSettings } = this.props
+
+    const hasHomeApp = homeSettings && homeSettings.address !== ''
+    if (hasHomeApp) {
+      if (onOpenApp) {
+        onOpenApp(homeSettings.address)
       }
-    })
+    }
   }
 
   state = {

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -141,7 +141,13 @@ class MenuPanel extends React.PureComponent {
     const { animate, scrollVisible, systemAppsOpened } = this.state
 
     const appGroups = this.getRenderableAppGroups(appInstanceGroups)
-    const menuApps = [APP_HOME, appGroups]
+
+    const hasHomeApp = appGroups.some(app => {
+      return app.isHomeApp
+    })
+
+    const menuApps = !hasHomeApp ? [APP_HOME, appGroups] : appGroups
+
     const systemApps = [APP_PERMISSIONS, APP_APPS_CENTER, APP_SETTINGS]
 
     return (

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -265,7 +265,7 @@ class MenuPanel extends React.PureComponent {
   renderAppGroup(app, isSystem) {
     const { activeInstanceId, onOpenApp } = this.props
 
-    const { appId, name, icon, instances } = app
+    const { appId, name, icon, instances, menuName } = app
     const isActive =
       instances.findIndex(
         ({ instanceId }) => instanceId === activeInstanceId
@@ -274,7 +274,7 @@ class MenuPanel extends React.PureComponent {
     return (
       <div key={appId}>
         <MenuPanelAppGroup
-          name={name}
+          name={menuName || name}
           icon={icon}
           system={isSystem}
           instances={instances}

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -12,6 +12,7 @@ import {
   DaoAddressType,
   DaoStatusType,
   EthereumAddressType,
+  HomeSettingsType,
 } from '../../prop-types'
 import { DAO_STATUS_LOADING } from '../../symbols'
 import { staticApps } from '../../static-apps'
@@ -64,6 +65,7 @@ class MenuPanel extends React.PureComponent {
     onRequestEnable: PropTypes.func.isRequired,
     unreadActivityCount: PropTypes.number,
     viewportHeight: PropTypes.number,
+    homeSettings: HomeSettingsType,
   }
 
   _animateTimer = -1
@@ -136,18 +138,26 @@ class MenuPanel extends React.PureComponent {
       onOpenPreferences,
       unreadActivityCount,
       onRequestEnable,
+      homeSettings,
     } = this.props
 
     const { animate, scrollVisible, systemAppsOpened } = this.state
 
     const appGroups = this.getRenderableAppGroups(appInstanceGroups)
 
-    const hasHomeApp = appGroups.some(app => {
-      return app.isHomeApp
+    const hasHomeApp = homeSettings && homeSettings.address !== ''
+
+    const appGroupsSorted = appGroups.sort((app1, app2) => {
+      if (
+        // NOTE: Only managed to get instance id from instances.
+        app1.instances[0].instanceId === homeSettings.address ||
+        app2.instances[0].instanceId === homeSettings.address
+      ) {
+        return app1.instances[0].instanceId === homeSettings.address ? -1 : 1
+      }
     })
 
-    const menuApps = !hasHomeApp ? [APP_HOME, appGroups] : appGroups
-
+    const menuApps = !hasHomeApp ? [APP_HOME, appGroupsSorted] : appGroupsSorted
     const systemApps = [APP_PERMISSIONS, APP_APPS_CENTER, APP_SETTINGS]
 
     return (
@@ -173,7 +183,6 @@ class MenuPanel extends React.PureComponent {
           <Content ref={this._contentRef}>
             <div className="in" ref={this._innerContentRef}>
               <h1>Apps</h1>
-
               <div>
                 {menuApps.map(app =>
                   // If it's an array, it's the group being loaded from the ACL
@@ -263,14 +272,22 @@ class MenuPanel extends React.PureComponent {
   }
 
   renderAppGroup(app, isSystem) {
-    const { activeInstanceId, onOpenApp } = this.props
+    const { activeInstanceId, onOpenApp, homeSettings } = this.props
 
-    const { appId, name, icon, instances, menuName } = app
+    const { appId, name, icon, instances } = app
     const isActive =
       instances.findIndex(
         ({ instanceId }) => instanceId === activeInstanceId
       ) !== -1
 
+    let menuName
+    const hasHomeApp = homeSettings && homeSettings.address !== ''
+    if (hasHomeApp) {
+      const isHomeApp = instances[0].instanceId === homeSettings.address
+      if (isHomeApp) {
+        menuName = homeSettings.name
+      }
+    }
     return (
       <div key={appId}>
         <MenuPanelAppGroup

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -265,7 +265,7 @@ class MenuPanel extends React.PureComponent {
   renderAppGroup(app, isSystem) {
     const { activeInstanceId, onOpenApp } = this.props
 
-    const { appId, name, icon, instances, menuName } = app
+    const { appId, name, icon, instances, menuAlias } = app
     const isActive =
       instances.findIndex(
         ({ instanceId }) => instanceId === activeInstanceId
@@ -274,7 +274,7 @@ class MenuPanel extends React.PureComponent {
     return (
       <div key={appId}>
         <MenuPanelAppGroup
-          name={menuName || name}
+          name={menuAlias || name}
           icon={icon}
           system={isSystem}
           instances={instances}

--- a/src/environment.js
+++ b/src/environment.js
@@ -43,11 +43,6 @@ export const sortAppsPair = (app1, app2) => {
     return app1.isAragonOsInternalApp ? -1 : 1
   }
 
-  // Home app first
-  if (app1.isHomeApp || app2.isHomeApp) {
-    return app1.isHomeApp ? -1 : 1
-  }
-
   // Try to sort it if the app exists in the list
   if (index1 === -1 && index2 > -1) {
     return 1

--- a/src/environment.js
+++ b/src/environment.js
@@ -43,6 +43,11 @@ export const sortAppsPair = (app1, app2) => {
     return app1.isAragonOsInternalApp ? -1 : 1
   }
 
+  // Home app first
+  if (app1.isHomeApp || app2.isHomeApp) {
+    return app1.isHomeApp ? -1 : 1
+  }
+
   // Try to sort it if the app exists in the list
   if (index1 === -1 && index2 > -1) {
     return 1

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -141,6 +141,11 @@ export const DaoAddressType = PropTypes.shape({
   domain: PropTypes.string,
 })
 
+export const HomeSettingsType = PropTypes.shape({
+  address: EthereumAddressType,
+  name: PropTypes.string,
+})
+
 export const RenderFnType = PropTypes.oneOfType([
   PropTypes.func,
   PropTypes.oneOf([false]),

--- a/src/storage/storage-abi.json
+++ b/src/storage/storage-abi.json
@@ -1,0 +1,231 @@
+[{
+    "constant": true,
+    "inputs": [],
+    "name": "hasInitialized",
+    "outputs": [{
+        "name": "",
+        "type": "bool"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "_script",
+        "type": "bytes"
+    }],
+    "name": "getEVMScriptExecutor",
+    "outputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "getRecoveryVault",
+    "outputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "token",
+        "type": "address"
+    }],
+    "name": "allowRecoverability",
+    "outputs": [{
+        "name": "",
+        "type": "bool"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "appId",
+    "outputs": [{
+        "name": "",
+        "type": "bytes32"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "getInitializationBlock",
+    "outputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "_token",
+        "type": "address"
+    }],
+    "name": "transferToVault",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "_sender",
+        "type": "address"
+    }, {
+        "name": "_role",
+        "type": "bytes32"
+    }, {
+        "name": "_params",
+        "type": "uint256[]"
+    }],
+    "name": "canPerform",
+    "outputs": [{
+        "name": "",
+        "type": "bool"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "getEVMScriptRegistry",
+    "outputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "kernel",
+    "outputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "isPetrified",
+    "outputs": [{
+        "name": "",
+        "type": "bool"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "REGISTER_DATA_ROLE",
+    "outputs": [{
+        "name": "",
+        "type": "bytes32"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "key",
+        "type": "bytes32"
+    }],
+    "name": "Registered",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "executor",
+        "type": "address"
+    }, {
+        "indexed": false,
+        "name": "script",
+        "type": "bytes"
+    }, {
+        "indexed": false,
+        "name": "input",
+        "type": "bytes"
+    }, {
+        "indexed": false,
+        "name": "returnData",
+        "type": "bytes"
+    }],
+    "name": "ScriptResult",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "vault",
+        "type": "address"
+    }, {
+        "indexed": true,
+        "name": "token",
+        "type": "address"
+    }, {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+    }],
+    "name": "RecoverToVault",
+    "type": "event"
+}, {
+    "constant": false,
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "_key",
+        "type": "bytes32"
+    }, {
+        "name": "_value",
+        "type": "string"
+    }],
+    "name": "registerData",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "_key",
+        "type": "bytes32"
+    }],
+    "name": "getRegisteredData",
+    "outputs": [{
+        "name": "",
+        "type": "string"
+    }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+}]

--- a/src/storage/storage-wrapper.js
+++ b/src/storage/storage-wrapper.js
@@ -1,0 +1,21 @@
+import tokens from '@aragon/templates-tokens'
+import { soliditySha3 } from '../web3-utils'
+import storageAbi from './storage-abi.json'
+
+export function testTokensEnabled(network) {
+  return !!tokens[network]
+}
+const getContract = (web3, storageAddr) => {
+  return new web3.eth.Contract(storageAbi, storageAddr)
+}
+
+export default {
+  set: (web3, storageAddr, from, paramName, value) =>
+    getContract(web3, storageAddr)
+      .methods.registerData(soliditySha3(paramName), value)
+      .send({ from: from }),
+  get: (web3, storageAddr, from, paramName) =>
+    getContract(web3, storageAddr)
+      .methods.getRegisteredData(soliditySha3(paramName))
+      .call({ from: from }),
+}

--- a/src/storage/storage-wrapper.js
+++ b/src/storage/storage-wrapper.js
@@ -9,9 +9,9 @@ export default {
   set: (web3, storageAddr, from, paramName, value) =>
     getContract(web3, storageAddr)
       .methods.registerData(soliditySha3(paramName), value)
-      .send({ from: from }),
+      .send({ from }),
   get: (web3, storageAddr, from, paramName) =>
     getContract(web3, storageAddr)
       .methods.getRegisteredData(soliditySha3(paramName))
-      .call({ from: from }),
+      .call({ from }),
 }

--- a/src/storage/storage-wrapper.js
+++ b/src/storage/storage-wrapper.js
@@ -1,6 +1,10 @@
+import tokens from '@aragon/templates-tokens'
 import { soliditySha3 } from '../web3-utils'
 import storageAbi from './storage-abi.json'
 
+export function testTokensEnabled(network) {
+  return !!tokens[network]
+}
 const getContract = (web3, storageAddr) => {
   return new web3.eth.Contract(storageAbi, storageAddr)
 }
@@ -9,9 +13,9 @@ export default {
   set: (web3, storageAddr, from, paramName, value) =>
     getContract(web3, storageAddr)
       .methods.registerData(soliditySha3(paramName), value)
-      .send({ from }),
+      .send({ from: from }),
   get: (web3, storageAddr, from, paramName) =>
     getContract(web3, storageAddr)
       .methods.getRegisteredData(soliditySha3(paramName))
-      .call({ from }),
+      .call({ from: from }),
 }

--- a/src/storage/storage-wrapper.js
+++ b/src/storage/storage-wrapper.js
@@ -18,4 +18,6 @@ export default {
     getContract(web3, storageAddr)
       .methods.getRegisteredData(soliditySha3(paramName))
       .call({ from: from }),
+  subscribe: (web3, storageAddr, paramName, callback) =>
+    getContract(web3, storageAddr).events.Registered(paramName, callback),
 }

--- a/src/storage/storage-wrapper.js
+++ b/src/storage/storage-wrapper.js
@@ -1,10 +1,6 @@
-import tokens from '@aragon/templates-tokens'
 import { soliditySha3 } from '../web3-utils'
 import storageAbi from './storage-abi.json'
 
-export function testTokensEnabled(network) {
-  return !!tokens[network]
-}
 const getContract = (web3, storageAddr) => {
   return new web3.eth.Contract(storageAbi, storageAddr)
 }


### PR DESCRIPTION
# Home integration
Fixes #6 
Fixes #7 
Fixes #8 

## From [#6](https://github.com/AutarkLabs/aragon/issues/6)
- [x] Add home page section in Settings
- [x] Set default home setting
- [x] Hide default home from menu if another is selected
- [x] Rename tab name in menu
- [x] Reorder selected home to appear on top of the menu
- [x] Show/hide Home settings based on `aragon-storage` installation detection

**Notes**
If the option selected is "Use the default", we hide the Tab name field. This is because it needs more changes on Aragon and doesn't seem necessary.

## From [#7](https://github.com/AutarkLabs/aragon/issues/7)
- [x] Create `aragon-storage` background app
- [x] Handle get and set from contract
- [x] Provide home app in the react state

**Notes:**
ABI of the contract has been added directly into a JSON file. This probably needs improvement
We can also improve state handling and avoid a duplicate call to the contract.

_There is some caveat about the aragon-storage integration, since the alias and the app address are separate key-value pairs, 2 transactions are currently needed to change the setting, a possible solution would be applying a concatenation of both parameters, pending ask @Quazia for ideas on this_

## From [#8](https://github.com/AutarkLabs/aragon/issues/8)
- [x] Handle event parsing `Registered(Bytes32 key)`

**Notes:** We are forcing a reload when changing home app. So now it doesn't sync with other opened instances.

### How to run
Clone [aragon-storage](https://github.com/AutarkLabs/aragon-storage/tree/contract-improvements) on `contract-improvements` branch and run:
```cd aragon-storage && npm i && npm run start:ipfs:template```

On a new terminal cd into this repo and branch, then run: 
```npm run start:local```

Now you can open [http://localhost:3000/#/0x5b6a3301a67A4bfda9D3a528CaD34cac6e7F8070](http://localhost:3000/#/0x5b6a3301a67A4bfda9D3a528CaD34cac6e7F8070) 